### PR TITLE
Force ember-inflector v2.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "license": "MIT",
   "devDependencies": {
     "broccoli-asset-rev": "^2.2.0",
+    "ember-inflector": "2.2.0",
     "ember-ajax": "0.7.1",
     "ember-cli": "2.2.0-beta.6",
     "ember-cli-app-version": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "ember-data": "^2.3.0",
     "ember-disable-proxy-controllers": "^1.0.1",
     "ember-export-application-global": "^1.0.4",
+    "ember-inflector": "2.2.0",
     "ember-resolver": "^2.0.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "ember-data": "^2.3.0",
     "ember-disable-proxy-controllers": "^1.0.1",
     "ember-export-application-global": "^1.0.4",
-    "ember-inflector": "2.2.0",
     "ember-resolver": "^2.0.3"
   }
 }


### PR DESCRIPTION
as a workaround for the bug introduced in April.

See the following issues: 
  - https://github.com/emberjs/ember-inflector/issues/145
  - https://github.com/udacity/FEF-Quiz-Ember-Nested-Routes/issues/1